### PR TITLE
Do not throw when ALTERNATIVE_URL not set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,10 @@ import {
   const email = env.get('STACKOVERFLOW_EMAIL').required().asString();
   const password = env.get('STACKOVERFLOW_PASSWORD').required().asString();
 
-  const url =
-    env.get('ALTERNATIVE_URL').asUrlString() || 'https://stackoverflow.com/';
+  const alternativeUrl = env.get('ALTERNATIVE_URL').asString()?.trim();
+  const url = alternativeUrl
+    ? new URL(alternativeUrl).toString()
+    : 'https://stackoverflow.com/';
 
   const browser = await playwright['chromium'].launch();
   const page = await browser.newPage();


### PR DESCRIPTION
Bugfix for #18 #20 and https://github.com/connorads/stackoverflow-fanatic/commit/2edf8f79dd2ffa5a84a08ecef05dd05fdfee5392
(Note to self: Don't be cheeky, open PRs! Direct to `master` bit you)

### Error

```
/home/runner/work/stackoverflow-fanatic/stackoverflow-fanatic/node_modules/env-var/lib/variable.js:47
    throw new EnvVarError(errMsg)
          ^

EnvVarError: env-var: "ALTERNATIVE_URL" should be a valid URL
    at raiseError (/home/runner/work/stackoverflow-fanatic/stackoverflow-fanatic/node_modules/env-var/lib/variable.js:47:11)
    at Object.asUrlString (/home/runner/work/stackoverflow-fanatic/stackoverflow-fanatic/node_modules/env-var/lib/variable.js:106:9)
    at /home/runner/work/stackoverflow-fanatic/stackoverflow-fanatic/build/src/index.js:10:44
    at Object.<anonymous> (/home/runner/work/stackoverflow-fanatic/stackoverflow-fanatic/build/src/index.js:53:3)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47
```